### PR TITLE
fix: use `text` for main body copy

### DIFF
--- a/packages/catppuccin-starlight/styles/shared.css
+++ b/packages/catppuccin-starlight/styles/shared.css
@@ -1,3 +1,8 @@
+/* align with style guide for main body copy -> `text` */
+:root {
+  --sl-color-text: var(--sl-color-white);
+}
+
 header, .right-sidebar, .content-panel {
   border-color: var(--sl-color-hairline-light) !important;
 }


### PR DESCRIPTION

This change better aligns with Catppuccin's style guide and improves contrast.

Closes #44
