### PR TITLE
fix(right-sidebar): increase contrast of ToC

### DIFF
--- a/packages/catppuccin-starlight/styles/shared.css
+++ b/packages/catppuccin-starlight/styles/shared.css
@@ -3,6 +3,11 @@
   --sl-color-text: var(--sl-color-white);
 }
 
+/* increase contrast of ToC in the right sidebar */
+.right-sidebar-panel a:not(:hover):not([aria-current="true"]) {
+  color: var(--sl-color-gray-2);
+}
+
 header, .right-sidebar, .content-panel {
   border-color: var(--sl-color-hairline-light) !important;
 }


### PR DESCRIPTION
Increasing the contrast of the right sidebar, aligned with #45 

| Before | After |
| --- | --- |
| <img width="150" height="500" alt="image" src="https://github.com/user-attachments/assets/6ef601f8-bf47-4df5-acd1-343407365075" /> | <img width="150" height="500" alt="image" src="https://github.com/user-attachments/assets/c862fb00-9a6d-4e2f-8b5a-e1e6d7a6e2a8" /> |

